### PR TITLE
Make emv not require the useless 'ember'

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ In the chrome inspector javascript console, you can now use these functions:
 
 ### `emv`
 Short for EMber View. Its equivalent to typing `Ember.View.Views[thing]`.
+You can also omit the annoying 'ember' and just type the id
 
 ```javascript
 emv('ember2344')

--- a/console.js
+++ b/console.js
@@ -1,5 +1,8 @@
 function customConsole() {
   window.emv = function(id) {
+    if (id.indexOf('ember') === -1) {
+      id = 'ember' + id
+    }
     return Ember.View.views[id];
   };
   window.emkeys = function(obj, includeUnderscore) {


### PR DESCRIPTION
it always seemed silly to me that I needed to type ember in the id field.